### PR TITLE
Handle ElastiCache TLS and user group updates

### DIFF
--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -950,8 +950,20 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 			requestUpdate = true
 		}
 
+		var (
+			transitEncryptionOld, transitEncryptionNew bool
+			transitEncryptionChanged                   bool
+			userGroupChanged                           bool
+			userGroupAdd, userGroupRemove              []string
+		)
+
 		if d.HasChange("transit_encryption_enabled") {
-			input.TransitEncryptionEnabled = aws.Bool(d.Get("transit_encryption_enabled").(bool))
+			transitEncryptionChanged = true
+			o, n := d.GetChange("transit_encryption_enabled")
+			transitEncryptionOld = o.(bool)
+			transitEncryptionNew = n.(bool)
+
+			input.TransitEncryptionEnabled = aws.Bool(transitEncryptionNew)
 			requestUpdate = true
 		}
 
@@ -961,19 +973,83 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if d.HasChange("user_group_ids") {
+			userGroupChanged = true
 			o, n := d.GetChange("user_group_ids")
 			ns, os := n.(*schema.Set), o.(*schema.Set)
 			add, del := ns.Difference(os), os.Difference(ns)
 
 			if add.Len() > 0 {
-				input.UserGroupIdsToAdd = flex.ExpandStringValueSet(add)
-				requestUpdate = true
+				userGroupAdd = flex.ExpandStringValueSet(add)
 			}
 
 			if del.Len() > 0 {
-				input.UserGroupIdsToRemove = flex.ExpandStringValueSet(del)
+				userGroupRemove = flex.ExpandStringValueSet(del)
+			}
+
+			if len(userGroupAdd) > 0 || len(userGroupRemove) > 0 {
 				requestUpdate = true
 			}
+		}
+
+		if transitEncryptionChanged && userGroupChanged {
+			switch {
+			case !transitEncryptionOld && transitEncryptionNew && len(userGroupAdd) > 0:
+				encInput := elasticache.ModifyReplicationGroupInput{
+					ApplyImmediately:         input.ApplyImmediately,
+					ReplicationGroupId:       input.ReplicationGroupId,
+					TransitEncryptionEnabled: input.TransitEncryptionEnabled,
+				}
+				if d.HasChange("transit_encryption_mode") {
+					encInput.TransitEncryptionMode = input.TransitEncryptionMode
+					input.TransitEncryptionMode = ""
+				}
+
+				updateFuncs = append(updateFuncs, func() error {
+					_, err := conn.ModifyReplicationGroup(ctx, &encInput)
+					if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
+						return nil
+					}
+					if err != nil {
+						return fmt.Errorf("modifying ElastiCache Replication Group (%s): %s", d.Id(), err)
+					}
+					return nil
+				})
+
+				input.TransitEncryptionEnabled = nil
+
+			case transitEncryptionOld && !transitEncryptionNew && len(userGroupRemove) > 0:
+				ugInput := elasticache.ModifyReplicationGroupInput{
+					ApplyImmediately:   input.ApplyImmediately,
+					ReplicationGroupId: aws.String(d.Id()),
+				}
+				if len(userGroupAdd) > 0 {
+					ugInput.UserGroupIdsToAdd = userGroupAdd
+				}
+				if len(userGroupRemove) > 0 {
+					ugInput.UserGroupIdsToRemove = userGroupRemove
+				}
+
+				updateFuncs = append(updateFuncs, func() error {
+					_, err := conn.ModifyReplicationGroup(ctx, &ugInput)
+					if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
+						return nil
+					}
+					if err != nil {
+						return fmt.Errorf("modifying ElastiCache Replication Group (%s): %s", d.Id(), err)
+					}
+					return nil
+				})
+
+				userGroupAdd = nil
+				userGroupRemove = nil
+			}
+		}
+
+		if len(userGroupAdd) > 0 {
+			input.UserGroupIdsToAdd = userGroupAdd
+		}
+		if len(userGroupRemove) > 0 {
+			input.UserGroupIdsToRemove = userGroupRemove
 		}
 
 		if requestUpdate {

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -607,6 +607,44 @@ func TestAccElastiCacheReplicationGroup_updateUserGroups(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheReplicationGroup_enableTLSAndUserGroup(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var rg awstypes.ReplicationGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	userGroup := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupConfig_tlsUserGroup_step1(rName, userGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccReplicationGroupConfig_tlsUserGroup_step2(rName, userGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
+					testAccCheckReplicationGroupUserGroup(ctx, resourceName, userGroup),
+					resource.TestCheckTypeSetElemAttr(resourceName, "user_group_ids.*", userGroup),
+				),
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheReplicationGroup_updateNodeSize(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -3771,6 +3809,78 @@ resource "aws_elasticache_replication_group" "test" {
   user_group_ids             = [aws_elasticache_user_group.test[%[3]d].id]
 }
 `, rName, userGroup, flag)
+}
+
+func testAccReplicationGroupConfig_tlsUserGroup_step1(rName, userGroup string) string {
+	return acctest.ConfigCompose(
+		testAccReplicationGroupConfig_transitEncryptionBase(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = "%[2]s"
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = "%[2]s"
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test.user_id]
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.micro"
+  num_cache_clusters         = "1"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  parameter_group_name       = "default.redis7"
+  engine_version             = "7.0"
+  transit_encryption_enabled = false
+  apply_immediately          = true
+}
+`, rName, userGroup),
+	)
+}
+
+func testAccReplicationGroupConfig_tlsUserGroup_step2(rName, userGroup string) string {
+	return acctest.ConfigCompose(
+		testAccReplicationGroupConfig_transitEncryptionBase(rName),
+		fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = "%[2]s"
+  user_name     = "default"
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "REDIS"
+  passwords     = ["password123456789"]
+}
+
+resource "aws_elasticache_user_group" "test" {
+  user_group_id = "%[2]s"
+  engine        = "REDIS"
+  user_ids      = [aws_elasticache_user.test.user_id]
+}
+
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id       = %[1]q
+  description                = "test description"
+  node_type                  = "cache.t2.micro"
+  num_cache_clusters         = "1"
+  port                       = 6379
+  subnet_group_name          = aws_elasticache_subnet_group.test.name
+  security_group_ids         = [aws_security_group.test.id]
+  parameter_group_name       = "default.redis7"
+  engine_version             = "7.0"
+  transit_encryption_enabled = true
+  transit_encryption_mode    = "preferred"
+  user_group_ids             = [aws_elasticache_user_group.test.id]
+  apply_immediately          = true
+}
+`, rName, userGroup),
+	)
 }
 
 func testAccReplicationGroupConfig_inVPC(rName string) string {

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -260,7 +260,7 @@ The following arguments are optional:
   Valid values are `preferred` and `required`.
   When enabling encryption on an existing replication group, this must first be set to `preferred` before setting it to `required` in a subsequent apply.
   See the `TransitEncryptionMode` field in the [`CreateReplicationGroup` API documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html) for additional details.
-* `user_group_ids` - (Optional) User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid. **NOTE:** This argument _is_ a set because the AWS specification allows for multiple IDs. However, in practice, AWS only allows a maximum size of one.
+* `user_group_ids` - (Optional) User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid. **NOTE:** This argument _is_ a set because the AWS specification allows for multiple IDs. However, in practice, AWS only allows a maximum size of one. Requires `transit_encryption_enabled = true`. When enabling encryption on an existing replication group, it must be enabled prior to associating user groups.
 
 ### Log Delivery Configuration
 


### PR DESCRIPTION
## Summary
- update replication group update logic to sequence TLS and user group changes
- document TLS requirement for user groups
- add test covering enabling TLS and user groups in one apply

## Testing
- `make test TEST=./internal/service/elasticache` *(fails: forbidden downloading modules)*

